### PR TITLE
fix(captions): stabilize four-line layout

### DIFF
--- a/scripts/caption-layout-smoke.mjs
+++ b/scripts/caption-layout-smoke.mjs
@@ -1,13 +1,51 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 import {
+  captionPanelHeight,
+  CAPTION_LINE_HEIGHT,
+  CAPTION_MAXIMUM_PANEL_HEIGHT,
   CAPTION_TOTAL_LINE_COUNT,
   captionTextWidth,
+  normalizeCaptionText,
   selectCaptionLines,
   wrapCaption,
 } from '../src/utils/captionLayout.ts'
 
 const HISTORY_CAPACITY = 49
 const CURRENT_CAPACITY = 39
+
+const overlayCss = await readFile(
+  new URL('../src/views/CaptionOverlay.css', import.meta.url),
+  'utf8',
+)
+const overlaySource = await readFile(
+  new URL('../src/views/CaptionOverlay.tsx', import.meta.url),
+  'utf8',
+)
+assert.match(
+  overlayCss,
+  new RegExp(
+    `\\.caption-badge \\{[\\s\\S]*?height: ${CAPTION_LINE_HEIGHT + 2}px;[\\s\\S]*?gap: 2px;`,
+  ),
+)
+assert.match(
+  overlayCss,
+  /\.caption-lines \{[\s\S]*?overflow: visible;/,
+)
+assert.match(
+  overlayCss,
+  /\.caption-badge small \{[\s\S]*?display: none;/,
+)
+assert.match(overlaySource, /resizeQueueRef\.current = resizeQueueRef\.current/)
+assert.match(
+  overlaySource,
+  /import\.meta\.env\.VITE_CAPTION_DEBUG_FIXTURE === 'stress'/,
+)
+
+assert.equal(
+  normalizeCaptionText('A\r\nB\rC\nD\u0085E\u2028F\u2029G'),
+  'A B C D E F G',
+)
 
 const fourFinals = selectCaptionLines(
   ['first final', 'second final', 'third final', 'fourth final'],
@@ -100,6 +138,23 @@ const chinese = selectCaptionLines(
 assert.equal(chinese.length, CAPTION_TOTAL_LINE_COUNT)
 assert.equal(chinese.filter(({ role }) => role === 'current').length, 3)
 assert.equal(chinese.filter(({ role }) => role === 'history').length, 1)
+
+const separatorStress = selectCaptionLines(
+  ['历史一', '历史二', '历史三', '历史四'],
+  '第一段\r\n第二段\r第三段\u0085第四段\u2028第五段\u2029第六段'.repeat(20),
+  HISTORY_CAPACITY,
+  CURRENT_CAPACITY,
+)
+assert.ok(separatorStress.length <= CAPTION_TOTAL_LINE_COUNT)
+assert.ok(
+  separatorStress.every(
+    ({ text }) => !/[\r\n\u0085\u2028\u2029]/u.test(text),
+  ),
+)
+
+assert.equal(captionPanelHeight(0), 54)
+assert.equal(captionPanelHeight(4), CAPTION_MAXIMUM_PANEL_HEIGHT)
+assert.equal(captionPanelHeight(40), CAPTION_MAXIMUM_PANEL_HEIGHT)
 
 console.log(
   JSON.stringify({

--- a/src/utils/captionLayout.ts
+++ b/src/utils/captionLayout.ts
@@ -1,4 +1,17 @@
 export const CAPTION_TOTAL_LINE_COUNT = 4
+export const CAPTION_MAX_HISTORY_ITEMS = CAPTION_TOTAL_LINE_COUNT
+export const CAPTION_HISTORY_LINE_CAPACITY = 49
+export const CAPTION_CURRENT_LINE_CAPACITY = 39
+export const CAPTION_PANEL_WIDTH = 760
+export const CAPTION_OUTER_PADDING = 10
+export const CAPTION_LINE_HEIGHT = 22
+export const CAPTION_LINE_SPACING = 4
+export const CAPTION_VERTICAL_PADDING = 10
+export const CAPTION_MINIMUM_PANEL_HEIGHT = 54
+export const CAPTION_MAXIMUM_PANEL_HEIGHT =
+  CAPTION_VERTICAL_PADDING * 2 +
+  CAPTION_TOTAL_LINE_COUNT * CAPTION_LINE_HEIGHT +
+  (CAPTION_TOTAL_LINE_COUNT - 1) * CAPTION_LINE_SPACING
 
 export interface CaptionDisplayLine {
   text: string
@@ -22,6 +35,13 @@ export function captionTextWidth(text: string): number {
     (width, character) => width + characterWidth(character),
     0,
   )
+}
+
+export function normalizeCaptionText(text: string): string {
+  // Streaming providers may return CR, NEL, or Unicode line/paragraph
+  // separators in addition to LF. Collapse all of them before wrapping so
+  // the layout calculation and WebView rendering share the same line model.
+  return text.replace(/[\s\u0085\u2028\u2029]+/gu, ' ').trim()
 }
 
 function takeTokenPrefix(
@@ -72,9 +92,7 @@ function splitLongToken(token: string, capacity: number): string[] {
  * which normally has no spaces, falls back to character wrapping.
  */
 export function wrapCaption(text: string, capacity: number): string[] {
-  const normalized = text
-    .replace(/\s+/gu, ' ')
-    .trim()
+  const normalized = normalizeCaptionText(text)
     .replace(/\s+([,.;:!?%，。；：！？、…）)\]}>」』》〉】〕〗〙〛’”])/gu, '$1')
     .replace(/([(【〔〖〘〚「『《〈‘“<[{])\s+/gu, '$1')
   if (!normalized || capacity <= 0) return []
@@ -165,4 +183,20 @@ export function selectCaptionLines(
     ...visibleHistory,
     ...visibleCurrent,
   ])
+}
+
+export function captionPanelHeight(lineCount: number): number {
+  const count = Math.min(
+    CAPTION_TOTAL_LINE_COUNT,
+    Math.max(1, Math.floor(lineCount)),
+  )
+  return Math.min(
+    CAPTION_MAXIMUM_PANEL_HEIGHT,
+    Math.max(
+      CAPTION_MINIMUM_PANEL_HEIGHT,
+      CAPTION_VERTICAL_PADDING * 2 +
+        count * CAPTION_LINE_HEIGHT +
+        Math.max(0, count - 1) * CAPTION_LINE_SPACING,
+    ),
+  )
 }

--- a/src/views/CaptionOverlay.css
+++ b/src/views/CaptionOverlay.css
@@ -43,8 +43,9 @@
   display: flex;
   max-height: 100px;
   flex-direction: column;
+  justify-content: flex-end;
   gap: 4px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .caption-line {
@@ -80,11 +81,11 @@
 .caption-badge {
   display: flex;
   width: 42px;
-  height: 33px;
+  height: 24px;
   flex: 0 0 42px;
   flex-direction: column;
   align-items: center;
-  gap: 1px;
+  gap: 2px;
   opacity: 0;
   pointer-events: none;
 }
@@ -122,12 +123,7 @@
 }
 
 .caption-badge small {
-  height: 9px;
-  color: rgba(255, 255, 255, 0.56);
-  font-size: 8px;
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
-  line-height: 9px;
+  display: none;
 }
 
 .caption-close {

--- a/src/views/CaptionOverlay.tsx
+++ b/src/views/CaptionOverlay.tsx
@@ -11,21 +11,21 @@ import {
   type CaptionOutputUpdate,
 } from '../services/captionOutput'
 import {
+  captionPanelHeight,
+  CAPTION_CURRENT_LINE_CAPACITY,
+  CAPTION_HISTORY_LINE_CAPACITY,
+  CAPTION_MAX_HISTORY_ITEMS,
+  CAPTION_OUTER_PADDING,
+  CAPTION_PANEL_WIDTH,
   CAPTION_TOTAL_LINE_COUNT,
   selectCaptionLines,
   type CaptionDisplayLine,
 } from '../utils/captionLayout'
 import './CaptionOverlay.css'
 
-const MAX_HISTORY_ITEMS = CAPTION_TOTAL_LINE_COUNT
-const HISTORY_LINE_CAPACITY = 49
-const CURRENT_LINE_CAPACITY = 39
-const PANEL_WIDTH = 760
-const OUTER_PADDING = 10
-const LINE_HEIGHT = 22
-const LINE_SPACING = 4
-const VERTICAL_PADDING = 10
-const MINIMUM_PANEL_HEIGHT = 54
+const DEBUG_STRESS_FIXTURE =
+  import.meta.env.DEV &&
+  import.meta.env.VITE_CAPTION_DEBUG_FIXTURE === 'stress'
 
 function overlapLength(previous: string, candidate: string): number {
   const maximum = Math.min(previous.length, candidate.length)
@@ -43,16 +43,6 @@ function removeCommittedPrefix(committed: string, candidate: string): string {
   return text.slice(overlapLength(committed, text))
 }
 
-function panelHeight(lineCount: number): number {
-  const count = Math.max(1, lineCount)
-  return Math.max(
-    MINIMUM_PANEL_HEIGHT,
-    VERTICAL_PADDING * 2 +
-      count * LINE_HEIGHT +
-      Math.max(0, count - 1) * LINE_SPACING,
-  )
-}
-
 export function CaptionOverlay() {
   const [history, setHistory] = useState<string[]>([])
   const [current, setCurrent] = useState('')
@@ -61,18 +51,20 @@ export function CaptionOverlay() {
   const [liveSeconds, setLiveSeconds] = useState(0)
   const committedRef = useRef('')
   const currentRef = useRef('')
+  const resizeQueueRef = useRef<Promise<void>>(Promise.resolve())
   const lines = useMemo(
     () =>
       selectCaptionLines(
         history,
         current,
-        HISTORY_LINE_CAPACITY,
-        CURRENT_LINE_CAPACITY,
+        CAPTION_HISTORY_LINE_CAPACITY,
+        CAPTION_CURRENT_LINE_CAPACITY,
       ),
     [current, history],
   )
-  const visibleLines: CaptionDisplayLine[] = lines.length
-    ? lines
+  const boundedLines = lines.slice(-CAPTION_TOTAL_LINE_COUNT)
+  const visibleLines: CaptionDisplayLine[] = boundedLines.length
+    ? boundedLines
     : [
         {
           text: '',
@@ -81,8 +73,45 @@ export function CaptionOverlay() {
           showsBadge: false,
         },
       ]
+  const visibleFinalLineCount = visibleLines.filter(
+    ({ role }) => role === 'history',
+  ).length
+  const visibleLiveLineCount = visibleLines.length - visibleFinalLineCount
+  const visiblePanelHeight = captionPanelHeight(visibleLines.length)
 
   useEffect(() => {
+    if (!DEBUG_STRESS_FIXTURE) return
+    const debugCurrent = [
+      '这是一段用于验证字幕小行上限的超长实时内容'.repeat(4),
+      '换行符压力测试',
+      '当前内容应该顶掉全部历史并且只保留最后四个小行'.repeat(3),
+    ].join('\r\n\u0085\u2028\u2029')
+    currentRef.current = debugCurrent
+    setHistory(['历史一', '历史二', '历史三', '历史四'])
+    setCurrent(debugCurrent)
+    setStatus('speech')
+    void getCurrentWindow().show().catch(() => undefined)
+  }, [])
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    console.debug('[caption-layout]', {
+      historyItems: history.length,
+      currentCharacters: current.length,
+      visibleFinalLines: visibleFinalLineCount,
+      visibleLiveLines: visibleLiveLineCount,
+      panelHeight: visiblePanelHeight,
+    })
+  }, [
+    current.length,
+    history.length,
+    visibleFinalLineCount,
+    visibleLiveLineCount,
+    visiblePanelHeight,
+  ])
+
+  useEffect(() => {
+    if (DEBUG_STRESS_FIXTURE) return
     let disposed = false
     let remove: (() => void) | undefined
     void listen<CaptionOutputUpdate>(CAPTION_UPDATE_EVENT, ({ payload }) => {
@@ -109,7 +138,9 @@ export function CaptionOverlay() {
       const finalText = text || currentRef.current
       if (finalText) {
         committedRef.current += finalText
-        setHistory((items) => [...items, finalText].slice(-MAX_HISTORY_ITEMS))
+        setHistory((items) =>
+          [...items, finalText].slice(-CAPTION_MAX_HISTORY_ITEMS),
+        )
       }
       currentRef.current = ''
       setCurrent('')
@@ -137,27 +168,34 @@ export function CaptionOverlay() {
   }, [status])
 
   useLayoutEffect(() => {
-    const resize = async () => {
-      const window = getCurrentWindow()
-      const [position, size, scaleFactor] = await Promise.all([
-        window.outerPosition(),
-        window.outerSize(),
-        window.scaleFactor(),
-      ])
-      const height = panelHeight(visibleLines.length) + OUTER_PADDING * 2
-      const physicalHeight = Math.round(height * scaleFactor)
-      await window.setSize(
-        new LogicalSize(PANEL_WIDTH + OUTER_PADDING * 2, height),
-      )
-      await window.setPosition(
-        new PhysicalPosition(
-          position.x,
-          position.y + size.height - physicalHeight,
-        ),
-      )
-    }
-    void resize()
-  }, [visibleLines.length])
+    const height = visiblePanelHeight + CAPTION_OUTER_PADDING * 2
+    // Caption events can change the row count while a previous native resize
+    // is still in flight. Serialize updates so an older one-row resize can
+    // never finish after and overwrite the latest four-row height.
+    resizeQueueRef.current = resizeQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const window = getCurrentWindow()
+        const [position, size, scaleFactor] = await Promise.all([
+          window.outerPosition(),
+          window.outerSize(),
+          window.scaleFactor(),
+        ])
+        const physicalHeight = Math.round(height * scaleFactor)
+        await window.setSize(
+          new LogicalSize(
+            CAPTION_PANEL_WIDTH + CAPTION_OUTER_PADDING * 2,
+            height,
+          ),
+        )
+        await window.setPosition(
+          new PhysicalPosition(
+            position.x,
+            position.y + size.height - physicalHeight,
+          ),
+        )
+      })
+  }, [visiblePanelHeight])
 
   const duration = `${Math.floor(liveSeconds / 60)
     .toString()
@@ -168,9 +206,13 @@ export function CaptionOverlay() {
       <section
         className="caption-panel"
         data-tauri-drag-region
-        style={{ height: panelHeight(visibleLines.length) }}
+        style={{ height: visiblePanelHeight }}
       >
-        <div className="caption-lines" data-tauri-drag-region>
+        <div
+          className="caption-lines"
+          data-tauri-drag-region
+          data-visible-line-count={visibleLines.length}
+        >
           {visibleLines.map((line, index) => (
             <div
               className={`caption-line role-${line.role}`}


### PR DESCRIPTION
## Summary

- enforce a hard four-line visual limit for the caption overlay, with LIVE lines evicting older FINAL lines
- centralize caption sizing and wrapping constants in `captionLayout.ts`
- normalize CR, NEL, Unicode line separators, and paragraph separators before wrapping
- serialize native window resizes so stale async updates cannot shrink a newer four-line layout
- tighten the LIVE badge spacing and add a development stress fixture plus regression checks

## Why

A single long recognition segment can wrap into many visual rows even when the caption history contains only four logical entries. Rapid row-count changes can also race native window resizes, leaving the overlay at an outdated height. The LIVE label and timer were additionally crowded inside the fixed 22px row.

## Impact

The overlay now displays at most four visual rows. Long LIVE content grows upward and replaces older FINAL rows while preserving the toolkit's existing behavior for FINAL-only captions, manual visibility, and the two-row LIVE status block.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`
- verified the release build in the installed macOS caption window with four visible rows
