### PR TITLE
修复：扩展页离线运行标签跟随主题强调色

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4042,9 +4042,9 @@ button.job-state {
   border-radius: 4px;
 }
 .execution-mode-tag.offline {
-  color: #31715f;
+  color: var(--primary-hover);
   background: var(--surface-soft);
-  border-color: #c7e3d8;
+  border-color: var(--primary-ring);
 }
 .execution-mode-tag.api {
   color: var(--primary);
@@ -4488,12 +4488,12 @@ button.job-state {
   line-height: 1.45;
 }
 .plugin-execution-banner.offline {
-  color: #31715f;
+  color: var(--primary-hover);
   background: var(--surface-soft);
-  border-color: #c7e3d8;
+  border-color: var(--primary-ring);
 }
 .plugin-execution-banner.offline small {
-  color: #527a6b;
+  color: var(--primary);
 }
 .plugin-execution-banner.api {
   color: var(--primary-hover);
@@ -4501,15 +4501,7 @@ button.job-state {
   border-color: var(--primary-ring);
 }
 .plugin-execution-banner.api small {
-  color: #527a6b;
-}
-:root[data-theme="dark"] .execution-mode-tag.offline,
-:root[data-theme="dark"] .plugin-execution-banner.offline {
-  color: #8fd4bd;
-  border-color: #3e5a50;
-}
-:root[data-theme="dark"] .plugin-execution-banner.offline small {
-  color: #a9cabe;
+  color: var(--primary);
 }
 .plugin-detail-actions {
   display: flex;


### PR DESCRIPTION
## 问题

切换主题强调色后，扩展页面中「离线运行」的模型/应用标签与横幅仍是硬编码绿色，不跟随主题；而「云端 API」标签已正确使用主题变量。

## 原因

`App.css` 中 `.execution-mode-tag.offline` 与 `.plugin-execution-banner.offline` 硬编码了绿色值（`#31715f` / `#c7e3d8` / `#527a6b`），且另有一段深色模式覆盖块也是硬编码。而 `.api` 变体已使用 `var(--primary-*)`。

## 修改

- 离线标签/横幅统一改用 `var(--primary-hover)`（文字）、`var(--primary-ring)`（边框），与相邻 `.api` 规则保持一致。
- `small` 文案改用 `var(--primary)`。
- 移除冗余的 `:root[data-theme="dark"]` 覆盖块——主题变量会自动适配深浅色与所有强调色（薄荷/靛蓝/琥珀/玫瑰）。

## 验证

Playwright 截图核对：
- 浅色 + 靛蓝：离线标签 `color rgb(65,84,154)`、边框 `rgba(77,99,176,.22)` ✓
- 深色 + 玫瑰：离线标签 `color rgb(233,186,196)`、边框 `rgba(223,166,178,.26)` ✓

离线与云端样式仍可区分（离线=中性底色，云端=主题软底色）。