### PR TITLE
优化侧边栏紧凑布局与模型名称可读性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable user-facing changes are documented here. The project follows
 
 ### Changed
 
+- Refined sidebar spacing and model-name hierarchy, added group counts and
+  full-name tooltips, and increased the default sidebar width to 260px.
+
 - Native macOS window controls have more balanced titlebar insets. Desktop
   commands prefer an installed Xcode 26+ SDK over older Command Line Tools
   so local Tahoe builds use the current native control appearance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,3 +62,10 @@ should update `CHANGELOG.md` and the relevant documentation.
 By contributing, you agree that your contribution is licensed under
 Apache-2.0. Be respectful, constructive, and careful with user audio and
 credentials. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Sidebar presentation
+
+Keep full model names and taxonomy labels (such as `Audio-to-Text`) in the
+sidebar. The default width is 260px; saved user widths take precedence. Model
+rows use 30px height, or 26px in compact mode. Bottom utility buttons remain
+icon-only with hover labels.

--- a/src/App.css
+++ b/src/App.css
@@ -9869,3 +9869,27 @@ body.detail-resizing .model-workspace {
 
 }
 
+
+/* Sidebar readability: compact rows and quiet section headings. */
+.model-sidebar .installed-models { padding: 4px 12px 8px; gap: 10px; }
+.model-sidebar .sidebar-model-group-label {
+  min-height: 24px;
+  padding: 0 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+.sidebar-group-count { margin-left: auto; font-size: 11px; font-variant-numeric: tabular-nums; }
+.model-sidebar .sidebar-model-group-items { padding: 2px 0 0; gap: 2px; }
+.model-sidebar .installed-model-button {
+  height: 30px;
+  min-height: 30px;
+  padding: 0 10px;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+.model-sidebar .installed-model-button.active { font-weight: 600; }
+:root[data-density='compact'] .model-sidebar .installed-model-button {
+  height: 26px;
+  min-height: 26px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,7 @@ const DEFAULT_VOICE_WORKFLOW_MODELS_KEY =
 const WORKFLOWS_ENABLED = false
 const APP_UPDATE_CHECK_INTERVAL_MS = 30 * 60_000
 const MODEL_CATALOG_REFRESH_INTERVAL_MS = 6 * 60 * 60_000
-const DEFAULT_SIDEBAR_WIDTH = 240
+const DEFAULT_SIDEBAR_WIDTH = 260
 const MIN_SIDEBAR_WIDTH = 200
 const MAX_SIDEBAR_WIDTH = 520
 const MIN_WORKSPACE_WIDTH = 480
@@ -1826,6 +1826,8 @@ function App() {
           className={`installed-model-button${active ? ' active' : ''}`}
           type="button"
           aria-label={plugin.name}
+          title={plugin.name}
+          aria-current={active ? 'page' : undefined}
           onMouseEnter={(event) => {
             startModelNameScroll(event.currentTarget)
           }}
@@ -1842,7 +1844,6 @@ function App() {
             selectPlugin(plugin.id)
           }}
         >
-          <span className="sidebar-model-dot" aria-hidden="true" />
           <span className="activity-model-name">
             <span className="activity-model-name-text">
               {plugin.name}
@@ -2302,6 +2303,7 @@ function App() {
                   onClick={() => toggleSidebarGroup(group.id)}
                 >
                   <span>{group.label}</span>
+                  <span className="sidebar-group-count">{models.length}</span>
                 </button>
                 {!collapsed && (
                   <div className="sidebar-model-group-items">


### PR DESCRIPTION
## Summary

调整侧边栏分类层级、行距和留白，保留完整模型名称与 Audio-to-Text、Text-to-Audio 等英文分类。模型行使用 30px 高度，紧凑模式为 26px；弱化分类标题、增加模型数量，移除无明确含义的灰点，选中模型加粗并提供完整名称 tooltip 和 aria-current。

默认侧栏宽度从 240px 调整为 260px，已保存的用户宽度继续优先。底部扩展与设置保持原来的纯图标横排样式。

## Scope

仅修改侧栏展示与相关文档，不修改模型标识、推理、数据或权限。更新 CHANGELOG.md 和 CONTRIBUTING.md。

## Verification

- npm run lint、npm run build、npm test、git diff --check 通过。
- 已在桌面预览检查布局，并验证分组折叠。
- cargo fmt --check、cargo clippy --all-targets、cargo test 全部通过。test result: ok. 90 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 0.13s。未执行真实模型推理，本次无模型逻辑变更。
