### PR TITLE
修复 macOS 关闭主窗口后无法从程序坞重新打开

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable user-facing changes are documented here. The project follows
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- On macOS, "quit on close" exits the entire application even while the hidden
+  captions window exists. Dock reopen recreates a missing main window instead of
+  leaving the application running without a usable window.
+
 ## 0.1.12 - 2026-09-06
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,24 @@ Keep full model names and taxonomy labels (such as `Audio-to-Text`) in the
 sidebar. The default width is 260px; saved user widths take precedence. Model
 rows use 30px height, or 26px in compact mode. Bottom utility buttons remain
 icon-only with hover labels.
+
+## macOS window lifecycle
+
+The red close button hides the main window by default. With "quit on close"
+enabled it must exit the entire application, including the hidden captions window.
+Dock reopen must show and focus a hidden/minimized window and recover a missing
+main window using its Tauri configuration.
+
+For lifecycle changes, run the native regression check in a disposable debug
+bundle with a separate identifier ending in `.windowtest`:
+
+```bash
+npm run tauri -- build --debug --bundles app --config '{"productName":"QwenAudio Window Test","identifier":"org.qwenaudio.toolkits.windowtest","bundle":{"createUpdaterArtifacts":false}}'
+node scripts/macos-window-smoke.mjs "src-tauri/target/debug/bundle/macos/QwenAudio Window Test.app"
+```
+
+Adjust the bundle path if `CARGO_TARGET_DIR` is set. Use Xcode 26+ on Tahoe.
+The smoke check sends actual close/minimize requests and Launch Services reopen
+Apple events, tests missing-window recovery, and verifies full process exit with
+the captions window present. It never runs against the normal app identifier or
+its settings/model data. The in-app hook is excluded from release builds.

--- a/scripts/macos-window-smoke.mjs
+++ b/scripts/macos-window-smoke.mjs
@@ -1,0 +1,41 @@
+// Run an isolated debug .app built with an identifier ending in .windowtest.
+import { execFileSync, spawn } from 'node:child_process'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve, join } from 'node:path'
+
+if (process.platform !== 'darwin' || !process.argv[2]) {
+  throw new Error('Usage on macOS: node scripts/macos-window-smoke.mjs /path/to/test.app')
+}
+const bundle = resolve(process.argv[2])
+const identifier = execFileSync('/usr/libexec/PlistBuddy', ['-c', 'Print CFBundleIdentifier', join(bundle, 'Contents/Info.plist')], { encoding: 'utf8' }).trim()
+if (!/^[\w.-]+\.windowtest$/.test(identifier)) throw new Error('Use a disposable .windowtest bundle')
+execFileSync('/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister', ['-f', bundle])
+const logs = mkdtempSync(join(tmpdir(), 'qwen-window-smoke-'))
+// Launch through Launch Services, just as Finder/Dock launches the installed app.
+const child = spawn('open', ['-W', '-n', bundle, '--env', 'QWEN_AUDIO_WINDOW_SMOKE_TEST=1', '--stdout', join(logs, 'stdout'), '--stderr', join(logs, 'stderr')], { stdio: 'inherit' })
+let timedOut = false
+const timeout = setTimeout(() => {
+  timedOut = true
+  try {
+    execFileSync('osascript', ['-e', `tell application id "${identifier}" to quit`], { timeout: 5000 })
+  } catch (error) {
+    console.error('Could not stop the disposable test app:', error.message)
+  } finally {
+    child.kill('SIGTERM')
+  }
+}, 60000)
+child.on('error', error => { clearTimeout(timeout); console.error(error); process.exitCode = 1 })
+child.on('exit', (code, signal) => {
+  clearTimeout(timeout)
+  let output = ''
+  for (const file of ['stdout', 'stderr']) {
+    try { output += readFileSync(join(logs, file), 'utf8') } catch { /* launch failure */ }
+  }
+  process.stdout.write(output)
+  const checks = ['close/reopen cycle 3 passed', 'minimize/reopen passed', 'missing-window recovery passed', 'requesting full exit with captions still present']
+  if (timedOut || code !== 0 || signal || checks.some(check => !output.includes(`WINDOW_SMOKE: ${check}`)) || output.includes('WINDOW_SMOKE: FAIL:')) {
+    console.error('Native window lifecycle test failed', { code, signal, logs })
+    process.exitCode = 1
+  } else console.log('PASS: native close, Dock reopen event, minimize, missing-window recovery, and full process exit')
+})

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ mod audio_io;
 mod audio_processing;
 mod downloads;
 mod harness;
+#[cfg(all(target_os = "macos", debug_assertions))]
+mod macos_window_smoke;
 mod onnx_audio;
 mod plugins;
 mod system_audio;
@@ -80,16 +82,37 @@ fn api_address(identifier: &str) -> &'static str {
 
 #[cfg(target_os = "macos")]
 fn restore_main_window(app: &tauri::AppHandle) {
-    let Some(window) = app.get_webview_window("main") else {
-        log::warn!("could not restore main window: window is unavailable");
-        return;
+    let window = match app.get_webview_window("main") {
+        Some(window) => window,
+        None => {
+            // A process can outlive its main window while the caption window exists.
+            let Some(config) = app
+                .config()
+                .app
+                .windows
+                .iter()
+                .find(|config| config.label == "main")
+            else {
+                log::error!("could not restore main window: configuration is unavailable");
+                return;
+            };
+            match tauri::WebviewWindowBuilder::from_config(app, config)
+                .and_then(|builder| builder.build())
+            {
+                Ok(window) => window,
+                Err(error) => {
+                    log::error!("could not recreate main window: {error}");
+                    return;
+                }
+            }
+        }
     };
 
-    if let Err(error) = window.unminimize() {
-        log::warn!("could not unminimize main window: {error}");
-    }
     if let Err(error) = window.show() {
         log::warn!("could not show main window: {error}");
+    }
+    if let Err(error) = window.unminimize() {
+        log::warn!("could not unminimize main window: {error}");
     }
     if let Err(error) = window.set_focus() {
         log::warn!("could not focus main window: {error}");
@@ -730,16 +753,22 @@ pub fn run() {
                 asr: app.state::<Arc<AsrRuntime>>().inner().clone(),
                 audio: app.state::<Arc<AudioProcessingRuntime>>().inner().clone(),
             });
+            #[cfg(all(target_os = "macos", debug_assertions))]
+            if std::env::var_os("QWEN_AUDIO_WINDOW_SMOKE_TEST").is_some() {
+                macos_window_smoke::start(app.handle().clone());
+            }
             Ok(())
         })
         .on_window_event(|window, event| {
             #[cfg(target_os = "macos")]
             if window.label() == "main" {
                 if let WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
                     if window.state::<CloseBehavior>().0.load(Ordering::Relaxed) {
+                        // Closing only `main` leaves the hidden caption window alive.
+                        window.app_handle().exit(0);
                         return;
                     }
-                    api.prevent_close();
                     if let Err(error) = window.hide() {
                         log::warn!("could not hide main window: {error}");
                     }

--- a/src-tauri/src/macos_window_smoke.rs
+++ b/src-tauri/src/macos_window_smoke.rs
@@ -1,0 +1,111 @@
+//! Opt-in native regression check. Run only in a disposable debug app bundle.
+use std::{
+    process::Command,
+    sync::atomic::Ordering,
+    thread,
+    time::{Duration, Instant},
+};
+use tauri::Manager;
+
+fn wait_for(label: &str, mut condition: impl FnMut() -> bool) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    while Instant::now() < deadline {
+        if condition() {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    Err(format!("timed out waiting for {label}"))
+}
+
+fn reopen(app: &tauri::AppHandle) -> Result<(), String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let bundle = exe
+        .ancestors()
+        .find(|p| p.extension().is_some_and(|ext| ext == "app"))
+        .ok_or("smoke test must run inside an .app bundle")?;
+    // Launch Services sends the same reopen Apple event as clicking the Dock icon.
+    let status = Command::new("open")
+        .arg(bundle)
+        .status()
+        .map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err("Launch Services could not reopen test app".into());
+    }
+    wait_for("visible, focused main window", || {
+        app.get_webview_window("main").is_some_and(|w| {
+            w.is_visible().unwrap_or(false)
+                && !w.is_minimized().unwrap_or(true)
+                && w.is_focused().unwrap_or(false)
+        })
+    })
+}
+
+fn check(app: &tauri::AppHandle) -> Result<(), String> {
+    // Let the frontend finish applying persisted settings before controlling them.
+    thread::sleep(Duration::from_secs(3));
+    app.state::<super::CloseBehavior>()
+        .0
+        .store(false, Ordering::Relaxed);
+    for cycle in 1..=3 {
+        let window = app
+            .get_webview_window("main")
+            .ok_or("main window is missing")?;
+        window.close().map_err(|e| e.to_string())?;
+        wait_for("hidden main window", || {
+            !window.is_visible().unwrap_or(true)
+        })?;
+        if app.get_webview_window("main").is_none() {
+            return Err("close destroyed the main window".into());
+        }
+        reopen(app)?;
+        eprintln!("WINDOW_SMOKE: close/reopen cycle {cycle} passed");
+    }
+    let window = app
+        .get_webview_window("main")
+        .ok_or("main window is missing")?;
+    window.minimize().map_err(|e| e.to_string())?;
+    wait_for("minimized main window", || {
+        window.is_minimized().unwrap_or(false)
+    })?;
+    reopen(app)?;
+    eprintln!("WINDOW_SMOKE: minimize/reopen passed");
+
+    window.destroy().map_err(|e| e.to_string())?;
+    wait_for("main window destruction", || {
+        app.get_webview_window("main").is_none()
+    })?;
+    reopen(app)?;
+    eprintln!("WINDOW_SMOKE: missing-window recovery passed");
+
+    // Keep an auxiliary window present to reproduce the original quit failure.
+    if app.get_webview_window("captions").is_none() {
+        return Err("caption test window is missing".into());
+    }
+    thread::sleep(Duration::from_secs(2));
+    app.state::<super::CloseBehavior>()
+        .0
+        .store(true, Ordering::Relaxed);
+    eprintln!("WINDOW_SMOKE: requesting full exit with captions still present");
+    app.get_webview_window("main")
+        .ok_or("main window is missing")?
+        .close()
+        .map_err(|e| e.to_string())?;
+    thread::sleep(Duration::from_secs(5));
+    Err("quit-on-close left the application running".into())
+}
+
+pub(super) fn start(app: tauri::AppHandle) {
+    // Protect normal app data from this opt-in destructive window test.
+    if !app.config().identifier.ends_with(".windowtest") {
+        eprintln!("WINDOW_SMOKE: refusing to run outside a .windowtest app");
+        app.exit(1);
+        return;
+    }
+    thread::spawn(move || {
+        if let Err(error) = check(&app) {
+            eprintln!("WINDOW_SMOKE: FAIL: {error}");
+            app.exit(1);
+        }
+    });
+}


### PR DESCRIPTION
## 问题与修复
macOS 开启“关闭时退出”后，红灯只销毁主窗口，隐藏的字幕窗口使进程继续运行；点击程序坞时没有主窗口可以恢复。

- 选择退出时显式退出整个应用，默认关闭隐藏行为保持不变。
- 程序坞重开时按配置重建缺失的主窗口，并显示、恢复最小化和聚焦窗口。
- 增加隔离的 macOS 原生窗口回归检查及运行说明，测试入口仅包含在 debug 构建中。

## 验证
- `npm run lint`、`npm run build`、`npm test` 通过。
- `cargo fmt --check`、`cargo clippy --all-targets` 通过；`cargo test`：99 通过，12 忽略。
- 原生测试通过：连续三次关闭/重开、最小化恢复、主窗口销毁后重建、字幕窗口存在时完整退出。
- macOS release 应用构建及签名校验通过。
